### PR TITLE
IfModule directives changes in upload/.htaccess

### DIFF
--- a/upload/.htaccess
+++ b/upload/.htaccess
@@ -1,5 +1,7 @@
-<IfModule mime.c>
+<IfModule mod_mime.c>
 	RemoveHandler .php .phtml .php3 .php4 .php5
 	RemoveType .php .phtml .php3 .php4 .php5
 </IfModule>
-php_flag engine off
+<IfModule mod_php5.c>
+	php_flag engine off
+</IfModule>


### PR DESCRIPTION
Changing IfModule mime.c to IfModule mod_mime.c. With mime.c RemoveHandler and RemoveType directives are ignored.

Adding IfModule mod_php5.c around php_flag directive. When PHP is run as CGI or FastCGI, php_flag directive without IfModule envelope causes 500 Internal Server Error.
